### PR TITLE
chore: update repo and dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"

--- a/.github/workflows/autotag-releases.yml
+++ b/.github/workflows/autotag-releases.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Get version from tag
         id: tag_name
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - "beta"
           - "stable"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Test toolchain file support
       - name: Write rust-toolchain.toml
@@ -93,7 +93,7 @@ jobs:
     name: Cache
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2025-04-23
+
+* Add support for installing rustup on Windows (#58 by @maennchen)
+    This adds support for using Rust on the GitHub provided Windows ARM runners.
+
 ## [1.11.0] - 2025-02-24
 
 * Add new parameter `cache-bin` that is propagated to `Swatinem/rust-cache` as `cache-bin` (#51 by @enkhjile)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2025-06-16
+
+* Add new parameter `cache-provider` that is propagated to `Swatinem/rust-cache` as `cache-provider` (#65 by @mindrunner)
+
 ## [1.12.0] - 2025-04-23
 
 * Add support for installing rustup on Windows (#58 by @maennchen)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2025-09-14
+
+* Add support for non-root source directory.
+    Accept source code and `rust-toolchain.toml` file in subdirectories of the repository.
+    Adds a new parameter `rust-src-dir` that controls the lookup for toolchain files and sets a default value for the `cache-workspace` input. (#69 by @Kubaryt)
+
 ## [1.14.1] - 2025-08-28
 
 * Pin `Swatinem/rust-cache` action to a full commit SHA (#68 by @JohnTitor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2025-08-23
+
+* Add new parameters `cache-all-crates` and `cache-workspace-crates` that are propagated to `Swatinem/rust-cache` as `cache-all-crates` and `cache-workspace-crates`
+
 ## [1.13.0] - 2025-06-16
 
 * Add new parameter `cache-provider` that is propagated to `Swatinem/rust-cache` as `cache-provider` (#65 by @mindrunner)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2025-08-28
+
+* Pin `Swatinem/rust-cache` action to a full commit SHA (#68 by @JohnTitor)
+
 ## [1.14.0] - 2025-08-23
 
 * Add new parameters `cache-all-crates` and `cache-workspace-crates` that are propagated to `Swatinem/rust-cache` as `cache-all-crates` and `cache-workspace-crates`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.1] - 2025-09-23
+
+* Update `Swatinem/rust-cache` to v2.8.1
+
 ## [1.15.0] - 2025-09-14
 
 * Add support for non-root source directory.

--- a/README.md
+++ b/README.md
@@ -48,22 +48,24 @@ If no `toolchain` value or toolchain file is present, it will default to `stable
 First, all items specified in the toolchain file are installed.
 Afterward, the `components` and `target` specified via inputs are installed in addition to the items from the toolchain file.
 
-| Name                | Description                                                                                                             | Default       |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `toolchain`         | Comma-separated list of Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`. The last version is the default. | stable        |
-| `target`            | Additional target support to install e.g. `wasm32-unknown-unknown`                                                      |               |
-| `components`        | Comma-separated string of additional components to install e.g. `clippy, rustfmt`                                       |               |
-| `cache`             | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                                                      | true          |
-| `cache-directories` | Propagates the value to [`Swatinem/rust-cache`]                                                                         |               |
-| `cache-workspaces`  | Propagates the value to [`Swatinem/rust-cache`]                                                                         |               |
-| `cache-on-failure`  | Propagates the value to [`Swatinem/rust-cache`]                                                                         | true          |
-| `cache-key`         | Propagates the value to [`Swatinem/rust-cache`] as `key`                                                                |               |
-| `cache-shared-key`  | Propagates the value to [`Swatinem/rust-cache`] as `shared-key`                                                         |               |
-| `cache-bin`         | Propagates the value to [`Swatinem/rust-cache`] as `cache-bin`                                                          | true          |
-| `cache-provider`    | Propagates the value to [`Swatinem/rust-cache`] as `cache-provider`                                                     | 'github'      |
-| `matcher`           | Enable problem matcher to surface build messages and formatting issues                                                  | true          |
-| `rustflags`         | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                  | "-D warnings" |
-| `override`          | Setup the last installed toolchain as the default via `rustup override`                                                 | true          |
+| Name                     | Description                                                                                                             | Default       |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `toolchain`              | Comma-separated list of Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`. The last version is the default. | stable        |
+| `target`                 | Additional target support to install e.g. `wasm32-unknown-unknown`                                                      |               |
+| `components`             | Comma-separated string of additional components to install e.g. `clippy, rustfmt`                                       |               |
+| `cache`                  | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                                                      | true          |
+| `cache-directories`      | Propagates the value to [`Swatinem/rust-cache`]                                                                         |               |
+| `cache-workspaces`       | Propagates the value to [`Swatinem/rust-cache`]                                                                         |               |
+| `cache-on-failure`       | Propagates the value to [`Swatinem/rust-cache`]                                                                         | true          |
+| `cache-key`              | Propagates the value to [`Swatinem/rust-cache`] as `key`                                                                |               |
+| `cache-shared-key`       | Propagates the value to [`Swatinem/rust-cache`] as `shared-key`                                                         |               |
+| `cache-bin`              | Propagates the value to [`Swatinem/rust-cache`] as `cache-bin`                                                          | true          |
+| `cache-provider`         | Propagates the value to [`Swatinem/rust-cache`] as `cache-provider`                                                     | 'github'      |
+| `cache-all-crates`       | Propagates the value to [`Swatinem/rust-cache`] as `cache-all-crates`                                                   | false         |
+| `cache-workspace-crates` | Propagates the value to [`Swatinem/rust-cache`] as `cache-workspace-crates`                                             | false         |
+| `matcher`                | Enable problem matcher to surface build messages and formatting issues                                                  | true          |
+| `rustflags`              | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                  | "-D warnings" |
+| `override`               | Setup the last installed toolchain as the default via `rustup override`                                                 | true          |
 
 [`Swatinem/rust-cache`]: https://github.com/Swatinem/rust-cache
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `matcher`                | Enable problem matcher to surface build messages and formatting issues                                                  | true          |
 | `rustflags`              | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                  | "-D warnings" |
 | `override`               | Setup the last installed toolchain as the default via `rustup override`                                                 | true          |
-| `rust-toolchain-dir`     | Path from root directory to directory with the rust toolchain file (if its not in the root of the repository)           |               |
+| `rust-src-dir`           | Path from root directory to directory with the Rust source directory (if its not in the root of the repository)         |               |
 
 [`Swatinem/rust-cache`]: https://github.com/Swatinem/rust-cache
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Caching for Rust tools and build artifacts is enabled.
 Environment variables are set to optimize the cache hits.
 [Problem Matchers] are provided for build messages (cargo, clippy) and formatting (rustfmt).
 
-The action is heavily inspired by *dtolnay*'s <https://github.com/dtolnay/rust-toolchain> and extends it with further features.
+The action is heavily inspired by _dtolnay_'s <https://github.com/dtolnay/rust-toolchain> and extends it with further features.
 
 ## Example workflow
 
@@ -48,21 +48,22 @@ If no `toolchain` value or toolchain file is present, it will default to `stable
 First, all items specified in the toolchain file are installed.
 Afterward, the `components` and `target` specified via inputs are installed in addition to the items from the toolchain file.
 
-| Name                | Description                                                                                                              | Default       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| `toolchain`         | Comma-separated list of Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`.  The last version is the default. | stable        |
-| `target`            | Additional target support to install e.g. `wasm32-unknown-unknown`                                                       |               |
-| `components`        | Comma-separated string of additional components to install e.g. `clippy, rustfmt`                                        |               |
-| `cache`             | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                                                       | true          |
-| `cache-directories` | Propagates the value to [`Swatinem/rust-cache`]                                                                          |               |
-| `cache-workspaces`  | Propagates the value to [`Swatinem/rust-cache`]                                                                          |               |
-| `cache-on-failure`  | Propagates the value to [`Swatinem/rust-cache`]                                                                          | true          |
-| `cache-key`         | Propagates the value to [`Swatinem/rust-cache`] as `key`                                                                 |               |
-| `cache-shared-key`  | Propagates the value to [`Swatinem/rust-cache`] as `shared-key`                                                          |               |
-| `cache-bin`         | Propagates the value to [`Swatinem/rust-cache`] as `cache-bin`                                                           | true          |
-| `matcher`           | Enable problem matcher to surface build messages and formatting issues                                                   | true          |
-| `rustflags`         | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                   | "-D warnings" |
-| `override`          | Setup the last installed toolchain as the default via `rustup override`                                                  | true          |
+| Name                | Description                                                                                                             | Default       |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `toolchain`         | Comma-separated list of Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`. The last version is the default. | stable        |
+| `target`            | Additional target support to install e.g. `wasm32-unknown-unknown`                                                      |               |
+| `components`        | Comma-separated string of additional components to install e.g. `clippy, rustfmt`                                       |               |
+| `cache`             | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                                                      | true          |
+| `cache-directories` | Propagates the value to [`Swatinem/rust-cache`]                                                                         |               |
+| `cache-workspaces`  | Propagates the value to [`Swatinem/rust-cache`]                                                                         |               |
+| `cache-on-failure`  | Propagates the value to [`Swatinem/rust-cache`]                                                                         | true          |
+| `cache-key`         | Propagates the value to [`Swatinem/rust-cache`] as `key`                                                                |               |
+| `cache-shared-key`  | Propagates the value to [`Swatinem/rust-cache`] as `shared-key`                                                         |               |
+| `cache-bin`         | Propagates the value to [`Swatinem/rust-cache`] as `cache-bin`                                                          | true          |
+| `cache-provider`    | Propagates the value to [`Swatinem/rust-cache`] as `cache-provider`                                                     | 'github'      |
+| `matcher`           | Enable problem matcher to surface build messages and formatting issues                                                  | true          |
+| `rustflags`         | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                  | "-D warnings" |
+| `override`          | Setup the last installed toolchain as the default via `rustup override`                                                 | true          |
 
 [`Swatinem/rust-cache`]: https://github.com/Swatinem/rust-cache
 
@@ -71,10 +72,10 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 By default, this action sets the `RUSTFLAGS` environment variable to `-D warnings`.
 However, rustflags sources are mutually exclusive, so setting this environment variable omits any configuration through `target.*.rustflags` or `build.rustflags`.
 
-* If `RUSTFLAGS` is already set, no modifications of the variable are made and the original value remains.
-* If `RUSTFLAGS` is unset and the `rustflags` input is empty (i.e., the empty string), then it will remain unset.
-    Use this, if you want to prevent the value from being set because you make use of `target.*.rustflags` or `build.rustflags`.
-* Otherwise, the environment variable `RUSTFLAGS` is set to the content of `rustflags`.
+- If `RUSTFLAGS` is already set, no modifications of the variable are made and the original value remains.
+- If `RUSTFLAGS` is unset and the `rustflags` input is empty (i.e., the empty string), then it will remain unset.
+  Use this, if you want to prevent the value from being set because you make use of `target.*.rustflags` or `build.rustflags`.
+- Otherwise, the environment variable `RUSTFLAGS` is set to the content of `rustflags`.
 
 To prevent this from happening, set the `rustflags` input to an empty string, which will
 prevent the action from setting `RUSTFLAGS` at all, keeping any existing preferences.
@@ -95,10 +96,10 @@ You can read more rustflags, and their load order, in the [Cargo reference].
 The action works best on the GitHub-hosted runners, but can work on self-hosted ones too, provided the necessary dependencies are available.
 PRs to add support for more environments are welcome.
 
-* bash 5
-* brew (macOS only)
-* rustup or curl
-* using other node actions
+- bash 5
+- brew (macOS only)
+- rustup or curl
+- using other node actions
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ PRs to add support for more environments are welcome.
 
 * bash 5
 * brew (macOS only)
-* rustup or curl (Linux and macOS)
+* rustup or curl
 * using other node actions
 
 ## License

--- a/README.md
+++ b/README.md
@@ -48,25 +48,25 @@ If no `toolchain` value or toolchain file is present, it will default to `stable
 First, all items specified in the toolchain file are installed.
 Afterward, the `components` and `target` specified via inputs are installed in addition to the items from the toolchain file.
 
-| Name                     | Description                                                                                                             | Default       |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `toolchain`              | Comma-separated list of Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`. The last version is the default. | stable        |
-| `target`                 | Additional target support to install e.g. `wasm32-unknown-unknown`                                                      |               |
-| `components`             | Comma-separated string of additional components to install e.g. `clippy, rustfmt`                                       |               |
-| `cache`                  | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                                                      | true          |
-| `cache-directories`      | Propagates the value to [`Swatinem/rust-cache`]                                                                         |               |
-| `cache-workspaces`       | Propagates the value to [`Swatinem/rust-cache`]                                                                         |               |
-| `cache-on-failure`       | Propagates the value to [`Swatinem/rust-cache`]                                                                         | true          |
-| `cache-key`              | Propagates the value to [`Swatinem/rust-cache`] as `key`                                                                |               |
-| `cache-shared-key`       | Propagates the value to [`Swatinem/rust-cache`] as `shared-key`                                                         |               |
-| `cache-bin`              | Propagates the value to [`Swatinem/rust-cache`] as `cache-bin`                                                          | true          |
-| `cache-provider`         | Propagates the value to [`Swatinem/rust-cache`] as `cache-provider`                                                     | 'github'      |
-| `cache-all-crates`       | Propagates the value to [`Swatinem/rust-cache`] as `cache-all-crates`                                                   | false         |
-| `cache-workspace-crates` | Propagates the value to [`Swatinem/rust-cache`] as `cache-workspace-crates`                                             | false         |
-| `matcher`                | Enable problem matcher to surface build messages and formatting issues                                                  | true          |
-| `rustflags`              | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                  | "-D warnings" |
-| `override`               | Setup the last installed toolchain as the default via `rustup override`                                                 | true          |
-| `rust-src-dir`           | Path from root directory to directory with the Rust source directory (if its not in the root of the repository)         |               |
+| Name                     | Description                                                                                                                                                                        | Default       |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `toolchain`              | Comma-separated list of Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`. The last version is the default.                                                            | stable        |
+| `target`                 | Additional target support to install e.g. `wasm32-unknown-unknown`                                                                                                                 |               |
+| `components`             | Comma-separated string of additional components to install e.g. `clippy, rustfmt`                                                                                                  |               |
+| `cache`                  | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                                                                                                                 | true          |
+| `cache-directories`      | Propagates the value to [`Swatinem/rust-cache`]                                                                                                                                    |               |
+| `cache-workspaces`       | Propagates the value to [`Swatinem/rust-cache`]. Influenced by the value of `rust-src-dir`.                                                                                        |               |
+| `cache-on-failure`       | Propagates the value to [`Swatinem/rust-cache`]                                                                                                                                    | true          |
+| `cache-key`              | Propagates the value to [`Swatinem/rust-cache`] as `key`                                                                                                                           |               |
+| `cache-shared-key`       | Propagates the value to [`Swatinem/rust-cache`] as `shared-key`                                                                                                                    |               |
+| `cache-bin`              | Propagates the value to [`Swatinem/rust-cache`] as `cache-bin`                                                                                                                     | true          |
+| `cache-provider`         | Propagates the value to [`Swatinem/rust-cache`] as `cache-provider`                                                                                                                | 'github'      |
+| `cache-all-crates`       | Propagates the value to [`Swatinem/rust-cache`] as `cache-all-crates`                                                                                                              | false         |
+| `cache-workspace-crates` | Propagates the value to [`Swatinem/rust-cache`] as `cache-workspace-crates`                                                                                                        | false         |
+| `matcher`                | Enable problem matcher to surface build messages and formatting issues                                                                                                             | true          |
+| `rustflags`              | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                                                                             | "-D warnings" |
+| `override`               | Setup the last installed toolchain as the default via `rustup override`                                                                                                            | true          |
+| `rust-src-dir`           | Path from root directory to directory with the Rust source directory (if its not in the root of the repository). Sets a default value for `cache-workspaces` that enables caching. |               |
 
 [`Swatinem/rust-cache`]: https://github.com/Swatinem/rust-cache
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `matcher`                | Enable problem matcher to surface build messages and formatting issues                                                  | true          |
 | `rustflags`              | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                  | "-D warnings" |
 | `override`               | Setup the last installed toolchain as the default via `rustup override`                                                 | true          |
+| `rust-toolchain-dir`     | Path from root directory to directory with the rust toolchain file (if its not in the root of the repository)           |               |
 
 [`Swatinem/rust-cache`]: https://github.com/Swatinem/rust-cache
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --all-features
 
@@ -30,7 +30,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Ensure rustfmt is installed and setup problem matcher
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
 
     - name: Setup Rust Caching
       if: inputs.cache == 'true'
-      uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      uses: believer-oss/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       with:
         workspaces: ${{ inputs.cache-workspaces || inputs.rust-src-dir }}
         cache-directories: ${{inputs.cache-directories}}

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: "Determines whether to cache ${CARGO_HOME}/bin."
     required: false
     default: "true"
+  cache-provider:
+    description: "Determines which provider to use for caching. Options are github or buildjet, defaults to github."
+    required: false
+    default: "github"
   matcher:
     description: "Enable the Rust problem matcher"
     required: false
@@ -214,5 +218,6 @@ runs:
         cache-directories: ${{inputs.cache-directories}}
         cache-on-failure: ${{inputs.cache-on-failure}}
         cache-bin: ${{inputs.cache-bin}}
+        cache-provider: ${{inputs.cache-provider}}
         key: ${{inputs.cache-key}}
         shared-key: ${{inputs.cache-shared-key}}

--- a/action.yml
+++ b/action.yml
@@ -130,13 +130,20 @@ runs:
       run: echo "::add-matcher::${{ github.action_path }}/rust.json"
 
     - name: Install rustup, if needed
-      if: runner.os != 'Windows'
       shell: bash
       run: |
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          
+          # Resolve the correct CARGO_HOME path depending on OS
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "${CARGO_HOME:-$USERPROFILE/.cargo}/bin" | sed 's|/|\\|g' >> $GITHUB_PATH
+          else
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          fi
         fi
+      env:
+        RUNNER_OS: "${{ runner.os }}"
 
     - name: rustup toolchain install ${{inputs.toolchain || 'stable'}}
       env:

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: "Additional non workspace directories to be cached, separated by newlines."
     required: false
   cache-on-failure:
-    description: "Also cache on workflow failures"
+    description: "Cache even if the build fails."
     default: "true"
     required: false
   cache-key:
@@ -46,9 +46,17 @@ inputs:
     required: false
     default: "true"
   cache-provider:
-    description: "Determines which provider to use for caching. Options are github or buildjet, defaults to github."
+    description: "Determines which provider to use for caching. Options are github, buildjet, or warpbuild. Defaults to github."
     required: false
     default: "github"
+  cache-all-crates:
+    description: "Determines which crates are cached. If `true` all crates will be cached, otherwise only dependent crates will be cached."
+    required: false
+    default: "false"
+  cache-workspace-crates:
+    description: "Determines which crates are cached. If `true` all crates will be cached, otherwise only dependent crates will be cached."
+    required: false
+    default: "false"
   matcher:
     description: "Enable the Rust problem matcher"
     required: false
@@ -138,7 +146,7 @@ runs:
       run: |
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          
+
           # Resolve the correct CARGO_HOME path depending on OS
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             echo "${CARGO_HOME:-$USERPROFILE/.cargo}/bin" | sed 's|/|\\|g' >> $GITHUB_PATH
@@ -219,5 +227,7 @@ runs:
         cache-on-failure: ${{inputs.cache-on-failure}}
         cache-bin: ${{inputs.cache-bin}}
         cache-provider: ${{inputs.cache-provider}}
+        cache-all-crates: ${{inputs.cache-all-crates}}
+        cache-workspace-crates: ${{inputs.cache-workspace-crates}}
         key: ${{inputs.cache-key}}
         shared-key: ${{inputs.cache-shared-key}}

--- a/action.yml
+++ b/action.yml
@@ -69,8 +69,8 @@ inputs:
     description: "Setup the last installed toolchain as the default via `rustup override`"
     required: false
     default: "true"
-  rust-toolchain-dir:
-    description: "Specify path from root directory to the directory to search for rust-toolchain.toml file. By default root directory will be used."
+  rust-src-dir:
+    description: "Specify path from root directory to the Rust source directory. By default root directory will be used."
     required: false
 
 outputs:
@@ -166,18 +166,18 @@ runs:
         targets: ${{inputs.target}}
         components: ${{inputs.components}}
         override: ${{inputs.override}}
-        rust_toolchain_dir: ${{inputs.rust-toolchain-dir}}
+        rust_src_dir: ${{inputs.rust-src-dir}}
       shell: bash
       run: |
-        if [[ -z "$toolchain" && ( -f "rust-toolchain" || -f "rust-toolchain.toml" || -f "$rust_toolchain_dir/rust-toolchain.toml") ]]
+        if [[ -d "$rust_src_dir" ]]; then
+          cd "$rust_src_dir"
+        fi
+        if [[ -z "$toolchain" && ( -f "rust-toolchain" || -f "rust-toolchain.toml") ]]
         then
           # Install the toolchain as specified in the file
           # rustup show is the old way that implicitly installed a toolchain
           # rustup toolchain install is the new explicit way
           # https://github.com/rust-lang/rustup/issues/3635#issuecomment-2343511297
-          if [[ -n "$rust_toolchain_dir" ]]; then
-              cd "$rust_toolchain_dir"
-          fi
           rustup show active-toolchain || rustup toolchain install
           if [[ -n $components ]]; then
             rustup component add ${components//,/ }

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,9 @@ inputs:
     description: "Setup the last installed toolchain as the default via `rustup override`"
     required: false
     default: "true"
+  rust-toolchain-dir:
+    description: "Specify path from root directory to the directory to search for rust-toolchain.toml file. By default root directory will be used."
+    required: false
 
 outputs:
   rustc-version:
@@ -163,14 +166,18 @@ runs:
         targets: ${{inputs.target}}
         components: ${{inputs.components}}
         override: ${{inputs.override}}
+        rust_toolchain_dir: ${{inputs.rust-toolchain-dir}}
       shell: bash
       run: |
-        if [[ -z "$toolchain" && ( -f "rust-toolchain" || -f "rust-toolchain.toml" ) ]]
+        if [[ -z "$toolchain" && ( -f "rust-toolchain" || -f "rust-toolchain.toml" || -f "$rust_toolchain_dir/rust-toolchain.toml") ]]
         then
           # Install the toolchain as specified in the file
           # rustup show is the old way that implicitly installed a toolchain
           # rustup toolchain install is the new explicit way
           # https://github.com/rust-lang/rustup/issues/3635#issuecomment-2343511297
+          if [[ -n "$rust_toolchain_dir" ]]; then
+              cd "$rust_toolchain_dir"
+          fi
           rustup show active-toolchain || rustup toolchain install
           if [[ -n $components ]]; then
             rustup component add ${components//,/ }

--- a/action.yml
+++ b/action.yml
@@ -229,7 +229,7 @@ runs:
       if: inputs.cache == 'true'
       uses: Swatinem/rust-cache@v2
       with:
-        workspaces: ${{inputs.cache-workspaces}}
+        workspaces: ${{ inputs.cache-workspaces || inputs.rust-src-dir }}
         cache-directories: ${{inputs.cache-directories}}
         cache-on-failure: ${{inputs.cache-on-failure}}
         cache-bin: ${{inputs.cache-bin}}

--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,7 @@ runs:
 
     - name: Setup Rust Caching
       if: inputs.cache == 'true'
-      uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+      uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       with:
         workspaces: ${{ inputs.cache-workspaces || inputs.rust-src-dir }}
         cache-directories: ${{inputs.cache-directories}}

--- a/action.yml
+++ b/action.yml
@@ -212,7 +212,7 @@ runs:
 
     - name: Setup Rust Caching
       if: inputs.cache == 'true'
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
       with:
         workspaces: ${{inputs.cache-workspaces}}
         cache-directories: ${{inputs.cache-directories}}


### PR DESCRIPTION
The believer-oss/rust-cache repo was a simple sync, then re-pointed it to our fork of `rust-cache`